### PR TITLE
fix(frontend): Unused typescript directive

### DIFF
--- a/frontend/lang/index.ts
+++ b/frontend/lang/index.ts
@@ -12,7 +12,6 @@ export const languages: Record<string, Translations> = {
   "zh-cn": { ...zhCN, ...minecraftZhCN },
   "zh-tw": { ...zhTW, ...minecraftZhTW },
   "zh-hk": { ...zhHK, ...minecraftZhHK },
-  //@ts-expect-error The missing keys in minecraftEnUS won't be used
   "en-us": { ...enUS, ...minecraftEnUS },
 };
 


### PR DESCRIPTION
Due to the minecraft 26.1 update, the `@ts-expect-error` directive is no longer needed in the `frontend/lang/index.ts` file