### PR TITLE
Adjust the layout of players page

### DIFF
--- a/frontend/app/panel/players/page.tsx
+++ b/frontend/app/panel/players/page.tsx
@@ -187,6 +187,7 @@ export default function Players() {
             ]}
             pagination
             paginationQueryKey="page"
+            outerClassName="contain-layout"
             fallbackMessage={$("players.empty")}/>
         </TabsContent>
         <TabsContent value="banned-list">
@@ -195,6 +196,7 @@ export default function Players() {
             data={bannedPlayers.filter(({ name }) => name.toLowerCase().includes(searchString.toLowerCase()))}
             pagination
             paginationQueryKey="banned-page"
+            outerClassName="contain-layout"
             fallbackMessage={$("players.empty")}/>
         </TabsContent>
       </Tabs>

--- a/frontend/app/panel/players/page.tsx
+++ b/frontend/app/panel/players/page.tsx
@@ -187,7 +187,6 @@ export default function Players() {
             ]}
             pagination
             paginationQueryKey="page"
-            outerClassName="contain-layout"
             fallbackMessage={$("players.empty")}/>
         </TabsContent>
         <TabsContent value="banned-list">
@@ -196,7 +195,6 @@ export default function Players() {
             data={bannedPlayers.filter(({ name }) => name.toLowerCase().includes(searchString.toLowerCase()))}
             pagination
             paginationQueryKey="banned-page"
-            outerClassName="contain-layout"
             fallbackMessage={$("players.empty")}/>
         </TabsContent>
       </Tabs>

--- a/frontend/app/panel/players/page.tsx
+++ b/frontend/app/panel/players/page.tsx
@@ -101,6 +101,7 @@ export default function Players() {
       description={$("players.description")}
       category={$("sidebar.management")}
       icon={<Users />}
+      pageClassName="min-xl:px-64!"
       className="flex flex-col gap-3">
       <span className="text-sm text-muted-foreground">{$("players.hint")}</span>
       <Tabs
@@ -109,7 +110,7 @@ export default function Players() {
           setCurrentTab(value as TabValueType);
           changeSettings("state.players.tab", value as TabValueType);
         }}>
-        <div className="flex justify-between items-end max-lg:flex-col-reverse max-lg:items-start">
+        <div className="flex flex-col-reverse items-start lg:flex-row lg:justify-between lg:items-end xl:flex-col-reverse xl:items-start 2xl:flex-row 2xl:justify-between 2xl:items-end">
           <TabsList>
             <TabsTrigger value="player-list">
               {`${$("players.player-list.title")} (${players.filter(({ isOnline }) => isOnline).length} / ${maxPlayerCount})`}
@@ -118,7 +119,7 @@ export default function Players() {
               {`${$("players.banned-list.title")} (${players.filter(({ isBanned }) => isBanned).length})`}
             </TabsTrigger>
           </TabsList>
-          <div className="min-w-fit border-b border-b-sidebar-border max-lg:border-b-transparent pb-1 flex gap-2 max-sm:flex-col max-sm:items-start *:cursor-pointer">
+          <div className="min-w-fit border-b border-b-transparent lg:border-b-sidebar-border xl:border-b-transparent 2xl:border-b-sidebar-border pb-1 flex gap-2 max-sm:flex-col max-sm:items-start *:cursor-pointer">
             <Button
               variant="ghost"
               title={$("players.action.refresh")}

--- a/frontend/app/panel/players/page.tsx
+++ b/frontend/app/panel/players/page.tsx
@@ -110,7 +110,7 @@ export default function Players() {
           setCurrentTab(value as TabValueType);
           changeSettings("state.players.tab", value as TabValueType);
         }}>
-        <div className="flex flex-col-reverse items-start lg:flex-row lg:justify-between lg:items-end xl:flex-col-reverse xl:items-start 2xl:flex-row 2xl:justify-between 2xl:items-end">
+        <div className="flex flex-col-reverse items-start gap-2 lg:flex-row lg:justify-between lg:items-end xl:flex-col-reverse xl:items-start 2xl:flex-row 2xl:justify-between 2xl:items-end">
           <TabsList>
             <TabsTrigger value="player-list">
               {`${$("players.player-list.title")} (${players.filter(({ isOnline }) => isOnline).length} / ${maxPlayerCount})`}

--- a/frontend/app/panel/players/page.tsx
+++ b/frontend/app/panel/players/page.tsx
@@ -110,7 +110,7 @@ export default function Players() {
           setCurrentTab(value as TabValueType);
           changeSettings("state.players.tab", value as TabValueType);
         }}>
-        <div className="flex flex-col-reverse items-start gap-2 lg:flex-row lg:justify-between lg:items-end xl:flex-col-reverse xl:items-start 2xl:flex-row 2xl:justify-between 2xl:items-end">
+        <div className="flex flex-col-reverse items-start gap-2 lg:flex-row lg:justify-between lg:items-end lg:gap-0 xl:flex-col-reverse xl:items-start xl:gap-2 2xl:flex-row 2xl:justify-between 2xl:items-end 2xl:gap-0">
           <TabsList>
             <TabsTrigger value="player-list">
               {`${$("players.player-list.title")} (${players.filter(({ isOnline }) => isOnline).length} / ${maxPlayerCount})`}

--- a/frontend/components/data-table.tsx
+++ b/frontend/components/data-table.tsx
@@ -29,8 +29,7 @@ export function DataTable<D, V>({
   pagination = false,
   paginationQueryKey,
   fallbackMessage = $("table.empty"),
-  className,
-  outerClassName
+  className
 }: {
   columns: ColumnDef<D, V>[]
   data: D[]
@@ -38,7 +37,6 @@ export function DataTable<D, V>({
   paginationQueryKey?: string
   fallbackMessage?: string
   className?: string
-  outerClassName?: string
 }) {
   const searchParams = useSearchParams();
   const pathname = usePathname();
@@ -94,7 +92,7 @@ export function DataTable<D, V>({
   }, [data.length, pagination, paginationQueryKey, paginationState.pageSize, searchParams]);
 
   return (
-    <div className={cn("flex flex-col gap-5", outerClassName)}>
+    <div className="flex flex-col gap-5">
       <div className={cn(className, "border rounded-md bg-background dark:bg-transparent")}>
         <Table>
           <TableHeader>

--- a/frontend/components/data-table.tsx
+++ b/frontend/components/data-table.tsx
@@ -29,7 +29,8 @@ export function DataTable<D, V>({
   pagination = false,
   paginationQueryKey,
   fallbackMessage = $("table.empty"),
-  className
+  className,
+  outerClassName
 }: {
   columns: ColumnDef<D, V>[]
   data: D[]
@@ -37,6 +38,7 @@ export function DataTable<D, V>({
   paginationQueryKey?: string
   fallbackMessage?: string
   className?: string
+  outerClassName?: string
 }) {
   const searchParams = useSearchParams();
   const pathname = usePathname();
@@ -92,7 +94,7 @@ export function DataTable<D, V>({
   }, [data.length, pagination, paginationQueryKey, paginationState.pageSize, searchParams]);
 
   return (
-    <div className="flex flex-col gap-5">
+    <div className={cn("flex flex-col gap-5", outerClassName)}>
       <div className={cn(className, "border rounded-md bg-background dark:bg-transparent")}>
         <Table>
           <TableHeader>


### PR DESCRIPTION
## Summary

- 为玩家页面（`frontend/app/panel/players/page.tsx`）添加 `pageClassName="min-xl:px-64!"`，与 settings/inventory/gamerules/open-api 等页面保持一致的页面横向留白。
- 调整玩家页面导航栏（TabList + 操作组件）的响应式排版：
  - **窗口宽度 ≥ 2xl** 与 **lg ≤ 窗口宽度 < xl**：左右分居一行（TabList 居左，操作组件居右）
  - **xl ≤ 窗口宽度 < 2xl** 与 **窗口宽度 < lg**：靠左上下排列（操作组件在上、TabList 在下）
- 同步调整操作组件容器底部边框的可见性，仅在与 TabList 同一行时显示，以延续 TabList 的下划线视觉效果。

## Test plan

- [ ] 窗口宽度 ≥ 1536px (2xl)：TabList 与操作组件分居左右一行
- [ ] 1280px ≤ 窗口宽度 < 1536px (xl ~ 2xl)：操作组件在上、TabList 在下，靠左排列
- [ ] 1024px ≤ 窗口宽度 < 1280px (lg ~ xl)：TabList 与操作组件分居左右一行
- [ ] 窗口宽度 < 1024px (< lg)：操作组件在上、TabList 在下，靠左排列
- [ ] 玩家列表 / 封禁列表 / 搜索 / 管理封禁IP / 启用白名单等交互均正常

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVitxV5gnrpJdDTBcxUiBN)_