### PR TITLE
ci: upload each jar as an independent artifact for on-demand downloads

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
           const client = new DefaultArtifactClient();
           const libsDir = path.resolve('build/libs');
           const jars = fs.readdirSync(libsDir)
-            .filter(f => /^opanel-.*-build\.jar$/.test(f))
+            .filter(f => /^opanel-.*-build.*\.jar$/.test(f))
             .sort();
           console.log(`Uploading ${jars.length} jars individually...`);
           for (const jar of jars) {

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,37 +84,25 @@ jobs:
 
     - name: Building jar files
       run: JAVA_HOME=$JAVA_HOME_25_X64 ./gradlew build --stacktrace
-    - name: Upload Bukkit/Spigot jars
-      uses: actions/upload-artifact@v4
-      with:
-        name: opanel-bukkit-jars
-        path: ./build/libs/opanel-bukkit-*-build.jar
-        if-no-files-found: warn
-
-    - name: Upload Folia jars
-      uses: actions/upload-artifact@v4
-      with:
-        name: opanel-folia-jars
-        path: ./build/libs/opanel-folia-*-build.jar
-        if-no-files-found: warn
-
-    - name: Upload Fabric jars
-      uses: actions/upload-artifact@v4
-      with:
-        name: opanel-fabric-jars
-        path: ./build/libs/opanel-fabric-*-build.jar
-        if-no-files-found: warn
-
-    - name: Upload Forge jars
-      uses: actions/upload-artifact@v4
-      with:
-        name: opanel-forge-jars
-        path: ./build/libs/opanel-forge-*-build.jar
-        if-no-files-found: warn
-
-    - name: Upload NeoForge jars
-      uses: actions/upload-artifact@v4
-      with:
-        name: opanel-neoforge-jars
-        path: ./build/libs/opanel-neoforge-*-build.jar
-        if-no-files-found: warn
+    - name: Upload individual jar artifacts
+      run: |
+        npm install --prefix /tmp/artifact-uploader @actions/artifact --silent
+        node << 'SCRIPT'
+        const { DefaultArtifactClient } = require('/tmp/artifact-uploader/node_modules/@actions/artifact');
+        const fs = require('fs');
+        const path = require('path');
+        (async () => {
+          const client = new DefaultArtifactClient();
+          const libsDir = path.resolve('build/libs');
+          const jars = fs.readdirSync(libsDir)
+            .filter(f => /^opanel-.*-build\.jar$/.test(f))
+            .sort();
+          console.log(`Uploading ${jars.length} jars individually...`);
+          for (const jar of jars) {
+            const name = path.basename(jar, '.jar');
+            process.stdout.write(`  ${name} ... `);
+            await client.uploadArtifact(name, [path.join(libsDir, jar)], libsDir);
+            console.log('done');
+          }
+        })().catch(e => { console.error(e); process.exit(1); });
+        SCRIPT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,8 +84,37 @@ jobs:
 
     - name: Building jar files
       run: JAVA_HOME=$JAVA_HOME_25_X64 ./gradlew build --stacktrace
-    - name: Upload artifacts
+    - name: Upload Bukkit/Spigot jars
       uses: actions/upload-artifact@v4
       with:
-        name: opanel-jars
-        path: ./build/libs/*
+        name: opanel-bukkit-jars
+        path: ./build/libs/opanel-bukkit-*-build.jar
+        if-no-files-found: warn
+
+    - name: Upload Folia jars
+      uses: actions/upload-artifact@v4
+      with:
+        name: opanel-folia-jars
+        path: ./build/libs/opanel-folia-*-build.jar
+        if-no-files-found: warn
+
+    - name: Upload Fabric jars
+      uses: actions/upload-artifact@v4
+      with:
+        name: opanel-fabric-jars
+        path: ./build/libs/opanel-fabric-*-build.jar
+        if-no-files-found: warn
+
+    - name: Upload Forge jars
+      uses: actions/upload-artifact@v4
+      with:
+        name: opanel-forge-jars
+        path: ./build/libs/opanel-forge-*-build.jar
+        if-no-files-found: warn
+
+    - name: Upload NeoForge jars
+      uses: actions/upload-artifact@v4
+      with:
+        name: opanel-neoforge-jars
+        path: ./build/libs/opanel-neoforge-*-build.jar
+        if-no-files-found: warn


### PR DESCRIPTION
## Summary

- 移除原来单一的 `opanel-jars`（~3GB zip）
- 构建完成后，通过 Node.js 脚本调用 `@actions/artifact` SDK，遍历 `build/libs/` 下所有 `opanel-*-build.jar`，将**每个 jar 单独上传为一个独立工件**
- 工件名称为 jar 文件名去掉 `.jar` 后缀（如 `opanel-bukkit-1.21-build`），可按需单独下载

## 实现说明

`upload-artifact` Action 本身无法在 bash 循环中调用。方案是在构建 job 内通过一个 `run` step 安装 `@actions/artifact` npm 包，然后用 Node.js heredoc 脚本循环上传，避免了额外 job 或 staging artifact 带来的大量冗余下载（matrix 方案每个 job 都要下载全量 ~3GB staging artifact，非常浪费）。

## Test plan

- [ ] 触发 CI 构建，确认每个 jar 均以独立工件形式出现（约 36 个）
- [ ] 确认每个工件仅包含对应的单个 jar 文件
- [ ] 确认可单独下载任意版本的 jar

https://claude.ai/code/session_013bMJ332JBUnpLngnn2Nbi1