### PR TITLE
Optimize the bundle size of minecraft textures

### DIFF
--- a/frontend/lib/texture.ts
+++ b/frontend/lib/texture.ts
@@ -9,5 +9,11 @@ export async function getTextures(version: string): Promise<Item[] | null> {
   }
 
   if(suitableVersion == null) return null;
-  return (await import(`minecraft-textures/dist/textures/json/${suitableVersion}.json`)).items;
+  
+  // Exclude unsupported versions: 1.12, 1.13, 1.14, 1.15, 1.17, 1.18
+  // along with the unused *.id.json siblings
+  return (await import(
+    /* webpackExclude: /\.id\.json$|^\.\/1\.(1[2-5]|17|18)\.json$/ */
+    `minecraft-textures-json/${suitableVersion}.json`
+  )).items;
 }

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,11 +1,29 @@
 import type { NextConfig } from "next";
+import path from "path";
+
+// `minecraft-textures` only exports individual `*.json` files via its `exports` field,
+// not the containing directory. Aliasing it lets the bundler enumerate the folder for
+// the dynamic `import()` in `lib/texture.ts` without hitting the exports restriction.
+const texturesJsonDir = path.join(
+  process.cwd(),
+  "node_modules/minecraft-textures/dist/textures/json"
+);
 
 const nextConfig: NextConfig = {
   distDir: "build",
   output: "export",
   trailingSlash: true,
   skipTrailingSlashRedirect: true,
-  reactStrictMode: false
+  reactStrictMode: false,
+  webpack: (config) => {
+    config.resolve.alias["minecraft-textures-json"] = texturesJsonDir;
+    return config;
+  },
+  turbopack: {
+    resolveAlias: {
+      "minecraft-textures-json": texturesJsonDir
+    }
+  }
 };
 
 export default nextConfig;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -35,7 +35,7 @@
         "markdown-to-jsx": "^9.5.7",
         "md5": "^2.3.0",
         "minecraft-skin-viewer": "^0.0.19",
-        "minecraft-textures": "^1.21.11",
+        "minecraft-textures": "^26.2.0",
         "monaco-editor": "^0.53.0",
         "monaco-yaml": "^5.4.0",
         "next": "15.5.19",
@@ -8648,9 +8648,9 @@
       }
     },
     "node_modules/minecraft-textures": {
-      "version": "1.21.11",
-      "resolved": "https://registry.npmjs.org/minecraft-textures/-/minecraft-textures-1.21.11.tgz",
-      "integrity": "sha512-J/Rp/VHzlpbjdixOxasDYIMBDgyX61ipkwjVJDNJ0YuLlrW20uxITD3aycPE9TJ28CL9uFGWNWxh3+2Gp4UQhw==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/minecraft-textures/-/minecraft-textures-26.2.0.tgz",
+      "integrity": "sha512-hXrT/7bBU0CeX0/sENHEweRfqqnnU6rqqILCG32RkkFui4sSsa2LhwnXkhSqixTNOtS9Zf3S5aELgbkXmziCAw==",
       "license": "GPL-3.0"
     },
     "node_modules/minimatch": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,7 +46,7 @@
     "markdown-to-jsx": "^9.5.7",
     "md5": "^2.3.0",
     "minecraft-skin-viewer": "^0.0.19",
-    "minecraft-textures": "^1.21.11",
+    "minecraft-textures": "^26.2.0",
     "monaco-editor": "^0.53.0",
     "monaco-yaml": "^5.4.0",
     "next": "15.5.19",


### PR DESCRIPTION
- Upgrade minecraft-textures to `26.2.0`
- Removed the unnecessary minecraft textures of versions not supported by opanel