### PR TITLE
chore: Migrate `dlc-fileops-helper` dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,16 +17,6 @@ allprojects {
     group = project.group
     version = project.version
 
-    repositories {
-        maven {
-            name = "CoZoooo"
-            url = "https://maven.cozozjw.cn/repository/maven-releases/"
-            content {
-                includeGroup "com.cozooo.dlc_manager"
-            }
-        }
-    }
-
     java {
         toolchain {
             languageVersion = JavaLanguageVersion.of(14)

--- a/fabric/fabric-1.19.4/build.gradle
+++ b/fabric/fabric-1.19.4/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     modImplementation "net.fabricmc:fabric-loader:${fabric_loader_version}"
     modImplementation "net.fabricmc.fabric-api:fabric-api:${fabric_api_version}+${minecraft_version}"
     include(modImplementation("space.nocp:configx:2.0.6"))
-    shadowImplementation "com.cozooo.dlc_manager:dlc-fileops-helper:1.0.1"
+    shadowImplementation "com.cozooo.dlc_manager:dlc_fileops_helper:1.0.1"
 
     shadowImplementation(project(":core")) {
         // To avoid conflict

--- a/fabric/fabric-1.19/build.gradle
+++ b/fabric/fabric-1.19/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     modImplementation "net.fabricmc:fabric-loader:${fabric_loader_version}"
     modImplementation "net.fabricmc.fabric-api:fabric-api:${fabric_api_version}+${minecraft_version}"
     include(modImplementation("space.nocp:configx:2.0.6"))
-    shadowImplementation "com.cozooo.dlc_manager:dlc-fileops-helper:1.0.1"
+    shadowImplementation "com.cozooo.dlc_manager:dlc_fileops_helper:1.0.1"
 
     shadowImplementation(project(":core")) {
         // To avoid conflict

--- a/fabric/fabric-1.20.2/build.gradle
+++ b/fabric/fabric-1.20.2/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     modImplementation "net.fabricmc:fabric-loader:${fabric_loader_version}"
     modImplementation "net.fabricmc.fabric-api:fabric-api:${fabric_api_version}+${minecraft_version}"
     include(modImplementation("space.nocp:configx:2.0.6"))
-    shadowImplementation "com.cozooo.dlc_manager:dlc-fileops-helper:1.0.1"
+    shadowImplementation "com.cozooo.dlc_manager:dlc_fileops_helper:1.0.1"
 
     shadowImplementation(project(":core")) {
         // To avoid conflict

--- a/fabric/fabric-1.20.3/build.gradle
+++ b/fabric/fabric-1.20.3/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     modImplementation "net.fabricmc:fabric-loader:${fabric_loader_version}"
     modImplementation "net.fabricmc.fabric-api:fabric-api:${fabric_api_version}+${minecraft_version}"
     include(modImplementation("space.nocp:configx:2.0.6"))
-    shadowImplementation "com.cozooo.dlc_manager:dlc-fileops-helper:1.0.1"
+    shadowImplementation "com.cozooo.dlc_manager:dlc_fileops_helper:1.0.1"
 
     shadowImplementation(project(":core")) {
         // To avoid conflict

--- a/fabric/fabric-1.20.5/build.gradle
+++ b/fabric/fabric-1.20.5/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     modImplementation "net.fabricmc:fabric-loader:${fabric_loader_version}"
     modImplementation "net.fabricmc.fabric-api:fabric-api:${fabric_api_version}+${minecraft_version}"
     include(modImplementation("space.nocp:configx:2.0.6"))
-    shadowImplementation "com.cozooo.dlc_manager:dlc-fileops-helper:1.0.1"
+    shadowImplementation "com.cozooo.dlc_manager:dlc_fileops_helper:1.0.1"
 
     shadowImplementation(project(":core")) {
         // To avoid conflict

--- a/fabric/fabric-1.20/build.gradle
+++ b/fabric/fabric-1.20/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     modImplementation "net.fabricmc:fabric-loader:${fabric_loader_version}"
     modImplementation "net.fabricmc.fabric-api:fabric-api:${fabric_api_version}+${minecraft_version}"
     include(modImplementation("space.nocp:configx:2.0.6"))
-    shadowImplementation "com.cozooo.dlc_manager:dlc-fileops-helper:1.0.1"
+    shadowImplementation "com.cozooo.dlc_manager:dlc_fileops_helper:1.0.1"
 
     shadowImplementation(project(":core")) {
         // To avoid conflict

--- a/fabric/fabric-1.21.11/build.gradle
+++ b/fabric/fabric-1.21.11/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     modImplementation "net.fabricmc:fabric-loader:${fabric_loader_version}"
     modImplementation "net.fabricmc.fabric-api:fabric-api:${fabric_api_version}+${minecraft_version}"
     include(modImplementation("space.nocp:configx:2.0.6"))
-    shadowImplementation "com.cozooo.dlc_manager:dlc-fileops-helper:1.0.1"
+    shadowImplementation "com.cozooo.dlc_manager:dlc_fileops_helper:1.0.1"
 
     shadowImplementation(project(":core")) {
         // To avoid conflict

--- a/fabric/fabric-1.21.2/build.gradle
+++ b/fabric/fabric-1.21.2/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     modImplementation "net.fabricmc:fabric-loader:${fabric_loader_version}"
     modImplementation "net.fabricmc.fabric-api:fabric-api:${fabric_api_version}+${minecraft_version}"
     include(modImplementation("space.nocp:configx:2.0.6"))
-    shadowImplementation "com.cozooo.dlc_manager:dlc-fileops-helper:1.0.1"
+    shadowImplementation "com.cozooo.dlc_manager:dlc_fileops_helper:1.0.1"
 
     shadowImplementation(project(":core")) {
         // To avoid conflict

--- a/fabric/fabric-1.21.5/build.gradle
+++ b/fabric/fabric-1.21.5/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     modImplementation "net.fabricmc:fabric-loader:${fabric_loader_version}"
     modImplementation "net.fabricmc.fabric-api:fabric-api:${fabric_api_version}+${minecraft_version}"
     include(modImplementation("space.nocp:configx:2.0.6"))
-    shadowImplementation "com.cozooo.dlc_manager:dlc-fileops-helper:1.0.1"
+    shadowImplementation "com.cozooo.dlc_manager:dlc_fileops_helper:1.0.1"
 
     shadowImplementation(project(":core")) {
         // To avoid conflict

--- a/fabric/fabric-1.21.9/build.gradle
+++ b/fabric/fabric-1.21.9/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     modImplementation "net.fabricmc:fabric-loader:${fabric_loader_version}"
     modImplementation "net.fabricmc.fabric-api:fabric-api:${fabric_api_version}+${minecraft_version}"
     include(modImplementation("space.nocp:configx:2.0.6"))
-    shadowImplementation "com.cozooo.dlc_manager:dlc-fileops-helper:1.0.1"
+    shadowImplementation "com.cozooo.dlc_manager:dlc_fileops_helper:1.0.1"
 
     shadowImplementation(project(":core")) {
         // To avoid conflict

--- a/fabric/fabric-1.21/build.gradle
+++ b/fabric/fabric-1.21/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     modImplementation "net.fabricmc:fabric-loader:${fabric_loader_version}"
     modImplementation "net.fabricmc.fabric-api:fabric-api:${fabric_api_version}+${minecraft_version}"
     include(modImplementation("space.nocp:configx:2.0.6"))
-    shadowImplementation "com.cozooo.dlc_manager:dlc-fileops-helper:1.0.1"
+    shadowImplementation "com.cozooo.dlc_manager:dlc_fileops_helper:1.0.1"
 
     shadowImplementation(project(":core")) {
         // To avoid conflict

--- a/fabric/fabric-26.1/build.gradle
+++ b/fabric/fabric-26.1/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     implementation "net.fabricmc:fabric-loader:${fabric_loader_version}"
     implementation "net.fabricmc.fabric-api:fabric-api:${fabric_api_version}+${minecraft_version}"
     include(implementation("space.nocp:configx:2.0.6"))
-    shadowImplementation "com.cozooo.dlc_manager:dlc-fileops-helper:1.0.1"
+    shadowImplementation "com.cozooo.dlc_manager:dlc_fileops_helper:1.0.1"
 
     shadowImplementation(project(":core")) {
         // To avoid conflict

--- a/fabric/fabric-helper-unmapped/build.gradle
+++ b/fabric/fabric-helper-unmapped/build.gradle
@@ -16,7 +16,7 @@ repositories {
 
 dependencies {
     minecraft "com.mojang:minecraft:${common_minecraft_version}"
-    implementation "com.cozooo.dlc_manager:dlc-fileops-helper:1.0.1"
+    implementation "com.cozooo.dlc_manager:dlc_fileops_helper:1.0.1"
     compileOnly "net.fabricmc:fabric-loader:${common_fabric_loader_version}"
     compileOnly "net.fabricmc.fabric-api:fabric-api:${common_fabric_api_version}+${common_minecraft_version}"
     compileOnly "space.nocp:configx:2.0.6"

--- a/fabric/fabric-helper/build.gradle
+++ b/fabric/fabric-helper/build.gradle
@@ -16,7 +16,7 @@ repositories {
 
 dependencies {
     minecraft "com.mojang:minecraft:${common_minecraft_version}"
-    implementation "com.cozooo.dlc_manager:dlc-fileops-helper:1.0.1"
+    implementation "com.cozooo.dlc_manager:dlc_fileops_helper:1.0.1"
     mappings "net.fabricmc:yarn:${common_yarn_mappings}:v2"
     modCompileOnly "net.fabricmc:fabric-loader:${common_fabric_loader_version}"
     modCompileOnly "net.fabricmc.fabric-api:fabric-api:${common_fabric_api_version}+${common_minecraft_version}"

--- a/forge/forge-1.19.4/build.gradle
+++ b/forge/forge-1.19.4/build.gradle
@@ -35,7 +35,7 @@ repositories {
 
 dependencies {
     implementation minecraft.dependency("net.minecraftforge:forge:${minecraft_version}-${forge_version}")
-    shadowImplementation "com.cozooo.dlc_manager:dlc-fileops-helper:1.0.1"
+    shadowImplementation "com.cozooo.dlc_manager:dlc_fileops_helper:1.0.1"
 
     shadowImplementation(project(":core")) {
         // To avoid conflict

--- a/forge/forge-1.20.1/build.gradle
+++ b/forge/forge-1.20.1/build.gradle
@@ -35,7 +35,7 @@ repositories {
 
 dependencies {
     implementation minecraft.dependency("net.minecraftforge:forge:${minecraft_version}-${forge_version}")
-    shadowImplementation "com.cozooo.dlc_manager:dlc-fileops-helper:1.0.1"
+    shadowImplementation "com.cozooo.dlc_manager:dlc_fileops_helper:1.0.1"
 
     shadowImplementation(project(":core")) {
         // To avoid conflict

--- a/forge/forge-1.20.2/build.gradle
+++ b/forge/forge-1.20.2/build.gradle
@@ -35,7 +35,7 @@ repositories {
 
 dependencies {
     implementation minecraft.dependency("net.minecraftforge:forge:${minecraft_version}-${forge_version}")
-    shadowImplementation "com.cozooo.dlc_manager:dlc-fileops-helper:1.0.1"
+    shadowImplementation "com.cozooo.dlc_manager:dlc_fileops_helper:1.0.1"
 
     shadowImplementation(project(":core")) {
         // To avoid conflict

--- a/forge/forge-1.20.3/build.gradle
+++ b/forge/forge-1.20.3/build.gradle
@@ -35,7 +35,7 @@ repositories {
 
 dependencies {
     implementation minecraft.dependency("net.minecraftforge:forge:${minecraft_version}-${forge_version}")
-    shadowImplementation "com.cozooo.dlc_manager:dlc-fileops-helper:1.0.1"
+    shadowImplementation "com.cozooo.dlc_manager:dlc_fileops_helper:1.0.1"
 
     shadowImplementation(project(":core")) {
         // To avoid conflict

--- a/forge/forge-1.20.6/build.gradle
+++ b/forge/forge-1.20.6/build.gradle
@@ -34,7 +34,7 @@ repositories {
 
 dependencies {
     implementation minecraft.dependency("net.minecraftforge:forge:${minecraft_version}-${forge_version}")
-    shadowImplementation "com.cozooo.dlc_manager:dlc-fileops-helper:1.0.1"
+    shadowImplementation "com.cozooo.dlc_manager:dlc_fileops_helper:1.0.1"
 
     shadowImplementation(project(":core")) {
         // To avoid conflict

--- a/forge/forge-1.21.11/build.gradle
+++ b/forge/forge-1.21.11/build.gradle
@@ -46,7 +46,7 @@ repositories {
 dependencies {
     implementation minecraft.dependency("net.minecraftforge:forge:${minecraft_version}-${forge_version}")
     annotationProcessor "net.minecraftforge:eventbus-validator:7.0-beta.12"
-    shadowImplementation "com.cozooo.dlc_manager:dlc-fileops-helper:1.0.1"
+    shadowImplementation "com.cozooo.dlc_manager:dlc_fileops_helper:1.0.1"
 
     shadowImplementation(project(":core")) {
         // To avoid conflict

--- a/forge/forge-1.21.3/build.gradle
+++ b/forge/forge-1.21.3/build.gradle
@@ -34,7 +34,7 @@ repositories {
 
 dependencies {
     implementation minecraft.dependency("net.minecraftforge:forge:${minecraft_version}-${forge_version}")
-    shadowImplementation "com.cozooo.dlc_manager:dlc-fileops-helper:1.0.1"
+    shadowImplementation "com.cozooo.dlc_manager:dlc_fileops_helper:1.0.1"
 
     shadowImplementation(project(":core")) {
         // To avoid conflict

--- a/forge/forge-1.21.5/build.gradle
+++ b/forge/forge-1.21.5/build.gradle
@@ -34,7 +34,7 @@ repositories {
 
 dependencies {
     implementation minecraft.dependency("net.minecraftforge:forge:${minecraft_version}-${forge_version}")
-    shadowImplementation "com.cozooo.dlc_manager:dlc-fileops-helper:1.0.1"
+    shadowImplementation "com.cozooo.dlc_manager:dlc_fileops_helper:1.0.1"
 
     shadowImplementation(project(":core")) {
         // To avoid conflict

--- a/forge/forge-1.21.8/build.gradle
+++ b/forge/forge-1.21.8/build.gradle
@@ -34,7 +34,7 @@ repositories {
 
 dependencies {
     implementation minecraft.dependency("net.minecraftforge:forge:${minecraft_version}-${forge_version}")
-    shadowImplementation "com.cozooo.dlc_manager:dlc-fileops-helper:1.0.1"
+    shadowImplementation "com.cozooo.dlc_manager:dlc_fileops_helper:1.0.1"
 
     shadowImplementation(project(":core")) {
         // To avoid conflict

--- a/forge/forge-1.21.9/build.gradle
+++ b/forge/forge-1.21.9/build.gradle
@@ -46,7 +46,7 @@ repositories {
 dependencies {
     implementation minecraft.dependency("net.minecraftforge:forge:${minecraft_version}-${forge_version}")
     annotationProcessor "net.minecraftforge:eventbus-validator:7.0-beta.12"
-    shadowImplementation "com.cozooo.dlc_manager:dlc-fileops-helper:1.0.1"
+    shadowImplementation "com.cozooo.dlc_manager:dlc_fileops_helper:1.0.1"
 
     shadowImplementation(project(":core")) {
         // To avoid conflict

--- a/forge/forge-1.21/build.gradle
+++ b/forge/forge-1.21/build.gradle
@@ -34,7 +34,7 @@ repositories {
 
 dependencies {
     implementation minecraft.dependency("net.minecraftforge:forge:${minecraft_version}-${forge_version}")
-    shadowImplementation "com.cozooo.dlc_manager:dlc-fileops-helper:1.0.1"
+    shadowImplementation "com.cozooo.dlc_manager:dlc_fileops_helper:1.0.1"
 
     shadowImplementation(project(":core")) {
         // To avoid conflict

--- a/forge/forge-26.1/build.gradle
+++ b/forge/forge-26.1/build.gradle
@@ -46,7 +46,7 @@ repositories {
 dependencies {
     implementation minecraft.dependency("net.minecraftforge:forge:${minecraft_version}-${forge_version}")
     annotationProcessor "net.minecraftforge:eventbus-validator:7.0-beta.12"
-    shadowImplementation "com.cozooo.dlc_manager:dlc-fileops-helper:1.0.1"
+    shadowImplementation "com.cozooo.dlc_manager:dlc_fileops_helper:1.0.1"
 
     shadowImplementation(project(":core")) {
         // To avoid conflict

--- a/forge/forge-helper/build.gradle
+++ b/forge/forge-helper/build.gradle
@@ -20,7 +20,7 @@ repositories {
 
 dependencies {
     implementation minecraft.dependency("net.minecraftforge:forge:${common_minecraft_version}-${common_forge_version}")
-    implementation "com.cozooo.dlc_manager:dlc-fileops-helper:1.0.1"
+    implementation "com.cozooo.dlc_manager:dlc_fileops_helper:1.0.1"
     compileOnly(project(":core"))
 }
 

--- a/neoforge/neoforge-1.21.1/build.gradle
+++ b/neoforge/neoforge-1.21.1/build.gradle
@@ -66,7 +66,7 @@ neoForge {
 }
 
 dependencies {
-    shadowImplementation "com.cozooo.dlc_manager:dlc-fileops-helper:1.0.1"
+    shadowImplementation "com.cozooo.dlc_manager:dlc_fileops_helper:1.0.1"
 
     shadowImplementation(project(":core")) {
         // To avoid conflict

--- a/neoforge/neoforge-1.21.3/build.gradle
+++ b/neoforge/neoforge-1.21.3/build.gradle
@@ -66,7 +66,7 @@ neoForge {
 }
 
 dependencies {
-    shadowImplementation "com.cozooo.dlc_manager:dlc-fileops-helper:1.0.1"
+    shadowImplementation "com.cozooo.dlc_manager:dlc_fileops_helper:1.0.1"
 
     shadowImplementation(project(":core")) {
         // To avoid conflict

--- a/neoforge/neoforge-1.21.5/build.gradle
+++ b/neoforge/neoforge-1.21.5/build.gradle
@@ -66,7 +66,7 @@ neoForge {
 }
 
 dependencies {
-    shadowImplementation "com.cozooo.dlc_manager:dlc-fileops-helper:1.0.1"
+    shadowImplementation "com.cozooo.dlc_manager:dlc_fileops_helper:1.0.1"
 
     shadowImplementation(project(":core")) {
         // To avoid conflict

--- a/neoforge/neoforge-helper/build.gradle
+++ b/neoforge/neoforge-helper/build.gradle
@@ -38,7 +38,7 @@ neoForge {
 }
 
 dependencies {
-    implementation "com.cozooo.dlc_manager:dlc-fileops-helper:1.0.1"
+    implementation "com.cozooo.dlc_manager:dlc_fileops_helper:1.0.1"
     compileOnly(project(":core")) {
         // To avoid conflict
         exclude group: 'com.github.oshi', module: 'oshi-core'

--- a/paper/folia-1.20.5/build.gradle
+++ b/paper/folia-1.20.5/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     compileOnly "org.apache.logging.log4j:log4j-core:2.24.1"
     compileOnly "com.mojang:brigadier:1.0.18"
     shadowImplementation "org.bstats:bstats-bukkit:3.2.1"
-    shadowImplementation "com.cozooo.dlc_manager:dlc-fileops-helper:1.0.1"
+    shadowImplementation "com.cozooo.dlc_manager:dlc_fileops_helper:1.0.1"
 
     shadowImplementation(project(":core")) {
         // To avoid conflict

--- a/paper/folia-1.20/build.gradle
+++ b/paper/folia-1.20/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     compileOnly "org.apache.logging.log4j:log4j-core:2.24.1"
     compileOnly "com.mojang:brigadier:1.0.18"
     shadowImplementation "org.bstats:bstats-bukkit:3.2.1"
-    shadowImplementation "com.cozooo.dlc_manager:dlc-fileops-helper:1.0.1"
+    shadowImplementation "com.cozooo.dlc_manager:dlc_fileops_helper:1.0.1"
 
     shadowImplementation(project(":core")) {
         // To avoid conflict

--- a/paper/folia-1.21.11/build.gradle
+++ b/paper/folia-1.21.11/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     compileOnly "org.apache.logging.log4j:log4j-core:2.24.1"
     compileOnly "com.mojang:brigadier:1.0.18"
     shadowImplementation "org.bstats:bstats-bukkit:3.2.1"
-    shadowImplementation "com.cozooo.dlc_manager:dlc-fileops-helper:1.0.1"
+    shadowImplementation "com.cozooo.dlc_manager:dlc_fileops_helper:1.0.1"
 
     shadowImplementation(project(":core")) {
         // To avoid conflict

--- a/paper/folia-1.21/build.gradle
+++ b/paper/folia-1.21/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     compileOnly "org.apache.logging.log4j:log4j-core:2.24.1"
     compileOnly "com.mojang:brigadier:1.0.18"
     shadowImplementation "org.bstats:bstats-bukkit:3.2.1"
-    shadowImplementation "com.cozooo.dlc_manager:dlc-fileops-helper:1.0.1"
+    shadowImplementation "com.cozooo.dlc_manager:dlc_fileops_helper:1.0.1"
 
     shadowImplementation(project(":core")) {
         // To avoid conflict

--- a/paper/folia-26.1.2/build.gradle
+++ b/paper/folia-26.1.2/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     compileOnly "org.apache.logging.log4j:log4j-core:2.24.1"
     compileOnly "com.mojang:brigadier:1.0.18"
     shadowImplementation "org.bstats:bstats-bukkit:3.2.1"
-    shadowImplementation "com.cozooo.dlc_manager:dlc-fileops-helper:1.0.1"
+    shadowImplementation "com.cozooo.dlc_manager:dlc_fileops_helper:1.0.1"
 
     shadowImplementation(project(":core")) {
         // To avoid conflict

--- a/paper/paper-1.19.4/build.gradle
+++ b/paper/paper-1.19.4/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     compileOnly "org.apache.logging.log4j:log4j-core:2.24.1"
     compileOnly "com.mojang:brigadier:1.0.18"
     shadowImplementation "org.bstats:bstats-bukkit:3.2.1"
-    shadowImplementation "com.cozooo.dlc_manager:dlc-fileops-helper:1.0.1"
+    shadowImplementation "com.cozooo.dlc_manager:dlc_fileops_helper:1.0.1"
 
     shadowImplementation(project(":core")) {
         // To avoid conflict

--- a/paper/paper-1.20.5/build.gradle
+++ b/paper/paper-1.20.5/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     compileOnly "org.apache.logging.log4j:log4j-core:2.24.1"
     compileOnly "com.mojang:brigadier:1.0.18"
     shadowImplementation "org.bstats:bstats-bukkit:3.2.1"
-    shadowImplementation "com.cozooo.dlc_manager:dlc-fileops-helper:1.0.1"
+    shadowImplementation "com.cozooo.dlc_manager:dlc_fileops_helper:1.0.1"
 
     shadowImplementation(project(":core")) {
         // To avoid conflict

--- a/paper/paper-1.20/build.gradle
+++ b/paper/paper-1.20/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     compileOnly "org.apache.logging.log4j:log4j-core:2.24.1"
     compileOnly "com.mojang:brigadier:1.0.18"
     shadowImplementation "org.bstats:bstats-bukkit:3.2.1"
-    shadowImplementation "com.cozooo.dlc_manager:dlc-fileops-helper:1.0.1"
+    shadowImplementation "com.cozooo.dlc_manager:dlc_fileops_helper:1.0.1"
 
     shadowImplementation(project(":core")) {
         // To avoid conflict

--- a/paper/paper-1.21.9/build.gradle
+++ b/paper/paper-1.21.9/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     compileOnly "org.apache.logging.log4j:log4j-core:2.24.1"
     compileOnly "com.mojang:brigadier:1.0.18"
     shadowImplementation "org.bstats:bstats-bukkit:3.2.1"
-    shadowImplementation "com.cozooo.dlc_manager:dlc-fileops-helper:1.0.1"
+    shadowImplementation "com.cozooo.dlc_manager:dlc_fileops_helper:1.0.1"
 
     shadowImplementation(project(":core")) {
         // To avoid conflict

--- a/paper/paper-1.21/build.gradle
+++ b/paper/paper-1.21/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     compileOnly "org.apache.logging.log4j:log4j-core:2.24.1"
     compileOnly "com.mojang:brigadier:1.0.18"
     shadowImplementation "org.bstats:bstats-bukkit:3.2.1"
-    shadowImplementation "com.cozooo.dlc_manager:dlc-fileops-helper:1.0.1"
+    shadowImplementation "com.cozooo.dlc_manager:dlc_fileops_helper:1.0.1"
 
     shadowImplementation(project(":core")) {
         // To avoid conflict

--- a/paper/paper-26.1/build.gradle
+++ b/paper/paper-26.1/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     compileOnly "org.apache.logging.log4j:log4j-core:2.24.1"
     compileOnly "com.mojang:brigadier:1.0.18"
     shadowImplementation "org.bstats:bstats-bukkit:3.2.1"
-    shadowImplementation "com.cozooo.dlc_manager:dlc-fileops-helper:1.0.1"
+    shadowImplementation "com.cozooo.dlc_manager:dlc_fileops_helper:1.0.1"
 
     shadowImplementation(project(":core")) {
         // To avoid conflict


### PR DESCRIPTION
Use mavenCentral for `dlc_fileops_helper` instead of `dlc-fileops-helper` from the self-hosted repository