### PR TITLE
fix: escape html tags in thrown error logs

### DIFF
--- a/frontend/components/terminal-viewer.tsx
+++ b/frontend/components/terminal-viewer.tsx
@@ -21,8 +21,6 @@ const ansiConverter = new AnsiConverter();
 const urlRegex = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,4}\b([-a-zA-Z0-9@:;%_\+.~#?&//=]*)/g;
 
 function preprocessLogLine(line: string): string {
-  line = purifyUnsafeText(line);
-
   if(getSettings("terminal.rich-style")) {
     line = ansiConverter.toHtml(parseTextToANSI(line.replaceAll("\x7f", secSign)));
   }
@@ -205,6 +203,11 @@ export function TerminalViewer({
     client.subscribe("init", (data: ConsoleLog[]) => {
       for(let i = data.length - MAX_LOG_LINES > 0 ? data.length - MAX_LOG_LINES : 0; i < data.length; i++) {
         data[i].line = purifyUnsafeText(data[i].line);
+        const thrownMessage = data[i].thrownMessage;
+        if(thrownMessage) {
+          data[i].thrownMessage = purifyUnsafeText(thrownMessage);
+        }
+
         data[i].uuid = uuidv7();
         logsBufferRef.current.push(data[i]);
       }
@@ -213,6 +216,10 @@ export function TerminalViewer({
 
     client.subscribe("log", (data: ConsoleLog) => {
       data.line = purifyUnsafeText(data.line);
+      if(data.thrownMessage) {
+        data.thrownMessage = purifyUnsafeText(data.thrownMessage);
+      }
+
       data.uuid = uuidv7();
       logsBufferRef.current.push(data);
       scheduleFlushLogsBuffer();
@@ -220,6 +227,10 @@ export function TerminalViewer({
 
     client.subscribe("mcdr-log", (data: ConsoleLog) => {
       data.line = purifyUnsafeText(data.line);
+      if(data.thrownMessage) {
+        data.thrownMessage = purifyUnsafeText(data.thrownMessage);
+      }
+      
       data.uuid = uuidv7();
       logsBufferRef.current.push(data);
       scheduleFlushLogsBuffer();

--- a/frontend/components/terminal-viewer.tsx
+++ b/frontend/components/terminal-viewer.tsx
@@ -21,6 +21,8 @@ const ansiConverter = new AnsiConverter();
 const urlRegex = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,4}\b([-a-zA-Z0-9@:;%_\+.~#?&//=]*)/g;
 
 function preprocessLogLine(line: string): string {
+  line = purifyUnsafeText(line);
+
   if(getSettings("terminal.rich-style")) {
     line = ansiConverter.toHtml(parseTextToANSI(line.replaceAll("\x7f", secSign)));
   }

--- a/frontend/components/tests/terminal-viewer.test.tsx
+++ b/frontend/components/tests/terminal-viewer.test.tsx
@@ -176,4 +176,64 @@ describe("test terminal viewer", () => {
     expect(screen.queryByText("line-1")).not.toBeInTheDocument();
     expect(screen.queryByText("line-2")).not.toBeInTheDocument();
   });
+
+  it("should escape html tags in log line", async () => {
+    const { client, emit } = createMockTerminalClient();
+    const { container } = render(<TerminalViewer client={client as any} levels={DEFAULT_LEVELS}/>);
+
+    const htmlTag = "<span class='malicious'>pwned</span>";
+    emit("log", createLog(1, { line: htmlTag }));
+
+    await waitFor(() => {
+      expect(container.querySelector("[data-slot='terminal-log']")).toBeInTheDocument();
+    });
+
+    const log = container.querySelector("[data-slot='terminal-log']");
+    expect(container.querySelector(".malicious")).not.toBeInTheDocument();
+    expect(log?.innerHTML).not.toContain(htmlTag);
+  });
+
+  it("should escape html tags in thrown message", async () => {
+    const { client, emit } = createMockTerminalClient();
+    const { container } = render(<TerminalViewer client={client as any} levels={DEFAULT_LEVELS}/>);
+
+    const htmlTag = "<div class='malicious'>pwned</div>";
+    emit("log", createLog(1, { thrownMessage: htmlTag }));
+
+    await waitFor(() => {
+      expect(container.querySelector("[data-slot='terminal-log']")).toBeInTheDocument();
+    });
+
+    const log = container.querySelector("[data-slot='terminal-log']");
+    expect(container.querySelector(".malicious")).not.toBeInTheDocument();
+    expect(log?.innerHTML).not.toContain(htmlTag);
+  });
+
+  it("should escape html from init log packets", async () => {
+    const { client, emit } = createMockTerminalClient();
+    const { container } = render(<TerminalViewer client={client as any} levels={DEFAULT_LEVELS}/>);
+
+    const htmlTag = "<script class='malicious'>alert(1)</script>";
+    emit("init", [createLog(1, { line: htmlTag, thrownMessage: htmlTag })]);
+
+    await waitFor(() => {
+      expect(container.querySelector("[data-slot='terminal-log']")).toBeInTheDocument();
+    });
+
+    expect(container.querySelector("script.malicious")).not.toBeInTheDocument();
+  });
+
+  it("should escape html from mcdr log packets", async () => {
+    const { client, emit } = createMockTerminalClient();
+    const { container } = render(<TerminalViewer client={client as any} levels={DEFAULT_LEVELS}/>);
+
+    const htmlTag = "<img class='malicious' src='x' onerror='alert(1)'/>";
+    emit("mcdr-log", createLog(1, { mcdr: true, line: htmlTag }));
+
+    await waitFor(() => {
+      expect(container.querySelector("[data-slot='terminal-log']")).toBeInTheDocument();
+    });
+
+    expect(container.querySelector("img.malicious")).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
close #443